### PR TITLE
test/e2e: Increase sleep time needed for alertmanager to settle

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -573,7 +573,7 @@ inhibit_rules:
 	}
 
 	// Wait for alert to propagate
-	time.Sleep(30 * time.Second)
+	time.Sleep(62 * time.Second)
 
 	opts := metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{


### PR DESCRIPTION
Value was chosen by adding previous value to a sum of results from throwing 20-sided dice twice. :smile:

Spawned by discussion in https://github.com/coreos/prometheus-operator/pull/2534